### PR TITLE
chore: add mock instill-model connector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/instill-ai/connector v0.0.0-20230628152420-4adf6bedec28
+	github.com/instill-ai/connector v0.0.0-20230630174544-1dc5a502a437
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230628145744-8bd74278dff2
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK8sZj0aUfI3TV1So=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
-github.com/instill-ai/connector v0.0.0-20230628152420-4adf6bedec28 h1:jgpEZiIZC+jJ7VZgibTg6eb+58a40mNPYp3RSiPR2VQ=
-github.com/instill-ai/connector v0.0.0-20230628152420-4adf6bedec28/go.mod h1:ctro5UDPVoLV7Toi6/cOar0JpYKtabvpXWmjtrXbce4=
+github.com/instill-ai/connector v0.0.0-20230630174544-1dc5a502a437 h1:7vxtzKS/38R6jy+ax8yCZUL8e8AkNE+i+9viPF89c20=
+github.com/instill-ai/connector v0.0.0-20230630174544-1dc5a502a437/go.mod h1:ctro5UDPVoLV7Toi6/cOar0JpYKtabvpXWmjtrXbce4=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230628145744-8bd74278dff2 h1:e8AG+hOq2FkIz2IRq+lEJBWKY3BhzgpmjOTHVVMBEcY=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230628145744-8bd74278dff2/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/pkg/instill/config/seed/definitions.json
+++ b/pkg/instill/config/seed/definitions.json
@@ -1,0 +1,51 @@
+[
+  {
+    "uid": "ddcf42c3-4c30-4c65-9585-25f1c89b2b48",
+    "id": "instill-ai-model",
+    "title": "Instill Model",
+    "documentationUrl": "https://www.instill.tech/docs/vdp/model-connectors/instill-model",
+    "icon": "instillmodel.svg",
+    "iconUrl": "",
+    "spec": {
+      "connectionSpecification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Stability AI Model Connector Spec",
+        "type": "object",
+        "required": [
+          "server_url",
+          "model_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "api_key": {
+            "credential_field": true,
+            "title": "API Key",
+            "description": "Access to your API keys can then be managed through the Setting page",
+            "type": "string"
+          },
+          "server_url": {
+            "title": "Server URL",
+            "description": "Base URL for the Instill Model API",
+            "type": "string",
+            "default": "https://api.instill.tech/model"
+          },
+          "model_id": {
+            "title": "Model ID",
+            "description": "ID of the model to use",
+            "type": "string"
+          }
+        }
+      },
+      "documentationUrl": "https://www.instill.tech/docs/model-connectors/instill-model"
+    },
+    "public": true,
+    "custom": false,
+    "vendorAttributes": {
+      "githubIssueLabel": "instill-model",
+      "license": "MIT",
+      "releaseStage": "alpha",
+      "resourceRequirements": {},
+      "modelType": "api"
+    }
+  }
+]

--- a/pkg/instill/main.go
+++ b/pkg/instill/main.go
@@ -1,0 +1,111 @@
+package instill
+
+import (
+	"sync"
+
+	_ "embed"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/connector/pkg/base"
+	"github.com/instill-ai/connector/pkg/configLoader"
+
+	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+)
+
+// Note: this is a dummy connector
+
+const vendorName = "instill"
+
+//go:embed config/seed/definitions.json
+var definitionJson []byte
+
+var once sync.Once
+var connector base.IConnector
+
+type Connector struct {
+	base.BaseConnector
+	options ConnectorOptions
+}
+
+type Connection struct {
+	base.BaseConnection
+	config *structpb.Struct
+}
+
+type ConnectorOptions struct{}
+
+func Init(logger *zap.Logger, options ConnectorOptions) base.IConnector {
+	once.Do(func() {
+		loader := configLoader.InitJSONSchema(logger)
+		connDefs, err := loader.Load(vendorName, connectorPB.ConnectorType_CONNECTOR_TYPE_AI, definitionJson)
+
+		if err != nil {
+			panic(err)
+		}
+
+		connector = &Connector{
+			BaseConnector: base.BaseConnector{Logger: logger},
+			options:       options,
+		}
+		for idx := range connDefs {
+			err := connector.AddConnectorDefinition(uuid.FromStringOrNil(connDefs[idx].GetUid()), connDefs[idx].GetId(), connDefs[idx])
+			if err != nil {
+				logger.Warn(err.Error())
+			}
+		}
+	})
+	return connector
+}
+
+func (c *Connector) CreateConnection(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (base.IConnection, error) {
+	return &Connection{
+		BaseConnection: base.BaseConnection{Logger: logger},
+		config:         config,
+	}, nil
+}
+
+func (con *Connection) Execute(inputs []*connectorPB.DataPayload) ([]*connectorPB.DataPayload, error) {
+
+	mock_data := []byte(`
+	{
+		"detection": {
+			"objects": [
+				{
+					"score": 0.9474398,
+					"category": "bear",
+					"boundingBox": {
+						"top": 455,
+						"left": 1372,
+						"width": 1300,
+						"height": 2178
+					}
+				}
+			]
+	  	}
+	}
+	`)
+
+	structuredData := &structpb.Struct{}
+	protojson.Unmarshal(mock_data, structuredData)
+	outputs := []*connectorPB.DataPayload{}
+	for idx := range inputs {
+		output := &connectorPB.DataPayload{
+			DataMappingIndex: inputs[idx].DataMappingIndex,
+			StructuredData:   structuredData,
+		}
+		outputs = append(outputs, output)
+	}
+	return outputs, nil
+}
+
+func (con *Connection) Test() (connectorPB.Connector_State, error) {
+	return connectorPB.Connector_STATE_CONNECTED, nil
+}
+
+func (con *Connection) GetTaskName() (string, error) {
+	return "TASK_DETECTION", nil
+}

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/instill-ai/connector-ai/pkg/instill"
 	"github.com/instill-ai/connector-ai/pkg/stabilityai"
 	"github.com/instill-ai/connector/pkg/base"
 )
@@ -18,22 +19,36 @@ var connector base.IConnector
 type Connector struct {
 	base.BaseConnector
 	stabilityAIConnector base.IConnector
+	instillConnector     base.IConnector
 }
 
 type ConnectorOptions struct {
 	StabilityAI stabilityai.ConnectorOptions
+	Instill     instill.ConnectorOptions
 }
 
 func Init(logger *zap.Logger, options ConnectorOptions) base.IConnector {
 	once.Do(func() {
 		stabilityAIConnector := stabilityai.Init(logger, options.StabilityAI)
+		instillConnector := instill.Init(logger, options.Instill)
 		connector = &Connector{
 			BaseConnector:        base.BaseConnector{Logger: logger},
 			stabilityAIConnector: stabilityAIConnector,
+			instillConnector:     instillConnector,
 		}
 
 		for _, uid := range stabilityAIConnector.ListConnectorDefinitionUids() {
 			def, err := stabilityAIConnector.GetConnectorDefinitionByUid(uid)
+			if err != nil {
+				logger.Error(err.Error())
+			}
+			err = connector.AddConnectorDefinition(uid, def.GetId(), def)
+			if err != nil {
+				logger.Warn(err.Error())
+			}
+		}
+		for _, uid := range instillConnector.ListConnectorDefinitionUids() {
+			def, err := instillConnector.GetConnectorDefinitionByUid(uid)
 			if err != nil {
 				logger.Error(err.Error())
 			}
@@ -50,7 +65,9 @@ func (c *Connector) CreateConnection(defUid uuid.UUID, config *structpb.Struct, 
 	switch {
 	case c.stabilityAIConnector.HasUid(defUid):
 		return c.stabilityAIConnector.CreateConnection(defUid, config, logger)
+	case c.instillConnector.HasUid(defUid):
+		return c.instillConnector.CreateConnection(defUid, config, logger)
 	default:
-		return nil, fmt.Errorf("no destinationConnector uid: %s", defUid)
+		return nil, fmt.Errorf("no aiConnector uid: %s", defUid)
 	}
 }

--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -28,8 +28,7 @@
             "description": "AI task type",
             "type": "string",
             "enum": [
-              "Text to Image",
-              "Image to Image"
+              "Text to Image"
             ]
           },
           "engine": {

--- a/pkg/stabilityai/main.go
+++ b/pkg/stabilityai/main.go
@@ -221,3 +221,8 @@ func (c *Connection) Test() (connectorPB.Connector_State, error) {
 	}
 	return connectorPB.Connector_STATE_CONNECTED, nil
 }
+
+func (con *Connection) GetTaskName() (string, error) {
+	// TODO: load from configuration
+	return "TASK_TEXT_TO_IMAGE", nil
+}


### PR DESCRIPTION
Because

- we need a mock instill-model connector for development purpose

This commit

- add mock instill-model connector
