### PR TITLE
chore: update definition id

### DIFF
--- a/pkg/instill/config/seed/definitions.json
+++ b/pkg/instill/config/seed/definitions.json
@@ -1,7 +1,7 @@
 [
   {
     "uid": "ddcf42c3-4c30-4c65-9585-25f1c89b2b48",
-    "id": "instill-ai-model",
+    "id": "ai-instill-model",
     "title": "Instill Model",
     "documentationUrl": "https://www.instill.tech/docs/vdp/model-connectors/instill-model",
     "icon": "instillmodel.svg",

--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -1,7 +1,7 @@
 [
   {
     "uid": "c86a95cc-7d32-4e22-a290-8c699f6705a4",
-    "id": "stability-ai-model",
+    "id": "ai-stability-ai",
     "title": "Stability AI",
     "documentationUrl": "https://www.instill.tech/docs/model-connectors/stability-ai",
     "icon": "stabilityai.svg",


### PR DESCRIPTION
Because

- need to rename the id for better naming convention
  - `instill-ai-model`-> `ai-instill-model`
  - `stability-ai-model` -> `ai-stability-ai`

This commit

- update definition id
