### PR TITLE
chore: update credential_field for stability ai connector

### DIFF
--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -19,6 +19,7 @@
         "additionalProperties": false,
         "properties": {
           "api_key": {
+            "credential_field": true,
             "title": "API Key",
             "description": "Access to your API keys can then be managed through Stability AI's Account page",
             "type": "string"


### PR DESCRIPTION
Because

- we need to mask the api_key

This commit

- update credential_field for stability ai connector
