### PR TITLE
chore: fix stability ai api_key name

### DIFF
--- a/pkg/stabilityai/main.go
+++ b/pkg/stabilityai/main.go
@@ -129,7 +129,7 @@ func (c *Client) sendReq(reqURL, method string, params interface{}, respObj inte
 }
 
 func (c *Connection) getAPIKey() string {
-	return fmt.Sprintf("%s", c.config.GetFields()["api_token"].GetStringValue())
+	return fmt.Sprintf("%s", c.config.GetFields()["api_key"].GetStringValue())
 }
 
 func (c *Connection) getTask() string {


### PR DESCRIPTION
Because

- chore: fix stability ai api_key name

This commit

- chore: fix stability ai api_key name
