### PR TITLE
Rename api_token to api_key for Stability AI

### DIFF
--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -12,13 +12,13 @@
         "title": "Stability AI AI Connector Spec",
         "type": "object",
         "required": [
-          "api_token",
+          "api_key",
           "task",
           "engine"
         ],
         "additionalProperties": false,
         "properties": {
-          "api_token": {
+          "api_key": {
             "credential_field": true,
             "title": "API Key",
             "description": "Fill your Stability AI API key. To find your keys, navigate to your DreamStudio's Account page.",

--- a/pkg/stabilityai/main.go
+++ b/pkg/stabilityai/main.go
@@ -129,7 +129,7 @@ func (c *Client) sendReq(reqURL, method string, params interface{}, respObj inte
 }
 
 func (c *Connection) getAPIKey() string {
-	return fmt.Sprintf("%s", c.config.GetFields()["api_token"].GetStringValue())
+	return fmt.Sprintf("%s", c.config.GetFields()["api_key"].GetStringValue())
 }
 
 func (c *Connection) getTask() string {


### PR DESCRIPTION
Because

- Stability AI calls it API key

This commit

- Renames api_token to api_key for Stability AI
