### PR TITLE
chore: fix text_to_image encode problem

### DIFF
--- a/pkg/instill/image_classification.go
+++ b/pkg/instill/image_classification.go
@@ -75,3 +75,8 @@ func encodeToBase64(input []byte) (string, error) {
 	}
 	return base64.StdEncoding.EncodeToString(input), nil
 }
+
+// decode the base64 string to bytesp[]
+func decodeFromBase64(b64str string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(b64str)
+}

--- a/pkg/instill/text_to_image.go
+++ b/pkg/instill/text_to_image.go
@@ -59,7 +59,11 @@ func (c *Connection) executeTextToImage(model *Model, inputs []*connectorPB.Data
 		images := [][]byte{}
 
 		for idx := range textToImgOutput.Images {
-			images = append(images, []byte(textToImgOutput.Images[idx]))
+			image, err := decodeFromBase64(textToImgOutput.Images[idx])
+			if err != nil {
+				return nil, fmt.Errorf("invalid output: %v for model: %s", textToImgOutput, model.Name)
+			}
+			images = append(images, image)
 		}
 
 		outputs = append(outputs, &connectorPB.DataPayload{


### PR DESCRIPTION
Because

- we should use []byte to store image, not base64

This commit

- fix text_to_image encode problem
