### PR TITLE
chore: allow insecure_connection

### DIFF
--- a/pkg/instill/client.go
+++ b/pkg/instill/client.go
@@ -1,12 +1,10 @@
 package instill
 
 import (
-	"crypto/tls"
 	"log"
 	"strings"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
@@ -15,11 +13,8 @@ import (
 // initModelPublicServiceClient initialises a ModelPublicServiceClient instance
 func initModelPublicServiceClient(serverURL string) (modelPB.ModelPublicServiceClient, *grpc.ClientConn) {
 	var clientDialOpts grpc.DialOption
-	if strings.HasPrefix(serverURL, "https://") {
-		clientDialOpts = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{}))
-	} else {
-		clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
-	}
+
+	clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
 	serverURL = stripProtocolFromURL(serverURL)
 	clientConn, err := grpc.Dial(serverURL, clientDialOpts)
 	if err != nil {

--- a/pkg/instill/main.go
+++ b/pkg/instill/main.go
@@ -2,6 +2,7 @@ package instill
 
 import (
 	"bytes"
+	"crypto/tls"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -126,6 +127,7 @@ func (c *Connection) NewClient() (*Client, error) {
 
 // sendReq is responsible for making the http request with to given URL, method, and params and unmarshalling the response into given object.
 func (c *Client) sendReq(reqURL, method string, params interface{}, respObj interface{}) (err error) {
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	data, _ := json.Marshal(params)
 	req, _ := http.NewRequest(method, reqURL, bytes.NewBuffer(data))
 	if c.APIKey != "" {


### PR DESCRIPTION
Because

- In the k8s cluster, we use internal connection. The cert will be illegal.

This commit

- allow insecure_connection
