### PR TITLE
chore: add new engines for stability ai

### DIFF
--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -38,17 +38,14 @@
             "type": "string",
             "default": "stable-diffusion-xl-beta-v2-2-2",
             "enum": [
-              "esrgan-v1-x2plus",
               "stable-diffusion-xl-1024-v0-9",
               "stable-diffusion-v1",
               "stable-diffusion-v1-5",
               "stable-diffusion-512-v2-0",
               "stable-diffusion-768-v2-0",
-              "stable-diffusion-depth-v2-0",
               "stable-diffusion-512-v2-1",
               "stable-diffusion-768-v2-1",
               "stable-diffusion-xl-beta-v2-2-2",
-              "stable-diffusion-x4-latent-upscaler",
               "stable-inpainting-v1-0",
               "stable-inpainting-512-v2-0"
             ]

--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -38,13 +38,17 @@
             "type": "string",
             "default": "stable-diffusion-xl-beta-v2-2-2",
             "enum": [
+              "esrgan-v1-x2plus",
+              "stable-diffusion-xl-1024-v0-9",
               "stable-diffusion-v1",
               "stable-diffusion-v1-5",
               "stable-diffusion-512-v2-0",
               "stable-diffusion-768-v2-0",
+              "stable-diffusion-depth-v2-0",
               "stable-diffusion-512-v2-1",
               "stable-diffusion-768-v2-1",
               "stable-diffusion-xl-beta-v2-2-2",
+              "stable-diffusion-x4-latent-upscaler",
               "stable-inpainting-v1-0",
               "stable-inpainting-512-v2-0"
             ]


### PR DESCRIPTION
Because

- some new engines are available on Stability AI

This commit

- adds the new engines to Stability AI definition
