### PR TITLE
chore: add new "Image to Image" task for Stability AI AI connector

### DIFF
--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -29,7 +29,8 @@
             "description": "AI task type.",
             "type": "string",
             "enum": [
-              "Text to Image"
+              "Text to Image",
+              "Image to Image"
             ]
           },
           "engine": {


### PR DESCRIPTION
Because

- we want to support the `Image to Image` task for Stability AI AI connector

This commit

- refactor the Stability AI JSON Schema
