### PR TITLE
chore: disable http keep-alive to prevent memory leak

### DIFF
--- a/pkg/instill/main.go
+++ b/pkg/instill/main.go
@@ -120,7 +120,8 @@ func (c *Connector) CreateConnection(defUid uuid.UUID, config *structpb.Struct, 
 // NewClient initializes a new Instill model client
 func (c *Connection) NewClient() (*Client, error) {
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		DisableKeepAlives: true,
 	}
 	return &Client{APIKey: c.getAPIKey(), HTTPClient: &http.Client{Timeout: reqTimeout, Transport: tr}}, nil
 }

--- a/pkg/openai/main.go
+++ b/pkg/openai/main.go
@@ -97,7 +97,10 @@ func (c *Connector) CreateConnection(defUid uuid.UUID, config *structpb.Struct, 
 
 // NewClient initializes a new Stability AI client
 func NewClient(apiKey string) Client {
-	return Client{APIKey: apiKey, HTTPClient: &http.Client{Timeout: reqTimeout}}
+	tr := &http.Transport{
+		DisableKeepAlives: true,
+	}
+	return Client{APIKey: apiKey, HTTPClient: &http.Client{Timeout: reqTimeout, Transport: tr}}
 }
 
 // sendReq is responsible for making the http request with to given URL, method, and params and unmarshalling the response into given object.

--- a/pkg/stabilityai/main.go
+++ b/pkg/stabilityai/main.go
@@ -98,7 +98,10 @@ func (c *Connector) CreateConnection(defUid uuid.UUID, config *structpb.Struct, 
 
 // NewClient initializes a new Stability AI client
 func NewClient(apiKey string) Client {
-	return Client{APIKey: apiKey, HTTPClient: &http.Client{Timeout: reqTimeout}}
+	tr := &http.Transport{
+		DisableKeepAlives: true,
+	}
+	return Client{APIKey: apiKey, HTTPClient: &http.Client{Timeout: reqTimeout, Transport: tr}}
 }
 
 // sendReq is responsible for making the http request with to given URL, method, and params and unmarshalling the response into given object.


### PR DESCRIPTION
Because

- memory leak problem

This commit

- disable http keep-alive to prevent memory leak
