### PR TITLE
chore: add category for instance segmentation

### DIFF
--- a/pkg/instill/instance_segmentation.go
+++ b/pkg/instill/instance_segmentation.go
@@ -63,8 +63,9 @@ func (c *Connection) executeInstanceSegmentation(grpcClient modelPB.ModelPublicS
 				Kind: &structpb.Value_StructValue{
 					StructValue: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
-							"rle":   {Kind: &structpb.Value_StringValue{StringValue: o.Rle}},
-							"score": {Kind: &structpb.Value_NumberValue{NumberValue: float64(o.Score)}},
+							"rle":      {Kind: &structpb.Value_StringValue{StringValue: o.Rle}},
+							"score":    {Kind: &structpb.Value_NumberValue{NumberValue: float64(o.Score)}},
+							"category": {Kind: &structpb.Value_StringValue{StringValue: o.Category}},
 							"bounding_box": {Kind: &structpb.Value_StructValue{
 								StructValue: &structpb.Struct{
 									Fields: map[string]*structpb.Value{

--- a/pkg/instill/text_to_image.go
+++ b/pkg/instill/text_to_image.go
@@ -62,8 +62,8 @@ func (c *Connection) executeTextToImage(grpcClient modelPB.ModelPublicServiceCli
 
 		images := [][]byte{}
 
-		for idx := range textToImgOutput.Images {
-			image, err := decodeFromBase64(textToImgOutput.Images[idx])
+		for imageIdx := range textToImgOutput.Images {
+			image, err := decodeFromBase64(textToImgOutput.Images[imageIdx])
 			if err != nil {
 				return nil, fmt.Errorf("invalid output: %v for model: %s", textToImgOutput, model.Name)
 			}


### PR DESCRIPTION
Because

- currently category is missing from output of instance segmentation task

This commit

- adds category to fix the output
