### PR TITLE
chore: update connector and protogen-go pkg to support audio data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/instill-ai/connector v0.2.0-alpha
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230717101605-87e3b68be4cf
+	github.com/instill-ai/connector v0.2.0-alpha.0.20230724051505-16610a2b30d4
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230724032341-29e39edfce64
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.24.0
 	google.golang.org/grpc v1.56.2

--- a/go.sum
+++ b/go.sum
@@ -14,10 +14,10 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK8sZj0aUfI3TV1So=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
-github.com/instill-ai/connector v0.2.0-alpha h1:9elA+XUIuxmIfa9gUzAFkuV/mjJQZfw1EEIGr8wFaiw=
-github.com/instill-ai/connector v0.2.0-alpha/go.mod h1:3kLmWi+0vdp4PfjRrolQQwOXU55HG1e1N9J7y83MBhw=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230717101605-87e3b68be4cf h1:E2D/N87Xcv+srNlr6BO8NvaLnLE+/F5QXgW140RWNVY=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230717101605-87e3b68be4cf/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/connector v0.2.0-alpha.0.20230724051505-16610a2b30d4 h1:EQlkZ1QsMY3/W4bF6qL3SjII1qEKEa0n6XKRefCzIY8=
+github.com/instill-ai/connector v0.2.0-alpha.0.20230724051505-16610a2b30d4/go.mod h1:8L3fikA244oinWaSQk7/zyJ3xb81HgGezoWFxNDXBgk=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230724032341-29e39edfce64 h1:L0CpYQ627By15NO+iQ3gLUeXumucTgWT7C/FF6rG0jo=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230724032341-29e39edfce64/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
Because

- we are going to support audio data in pipeline and connector

This commit

- update connector and protogen-go pkg to support audio data
