### PR TITLE
chore: use `ConnectorResource_State` enum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.19
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/connector v0.3.0-alpha.0.20230816101622-622978a8ce8b
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc
+	github.com/instill-ai/connector v0.3.0-alpha.0.20230817134809-bb4a86dbaaea
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.24.0
 	google.golang.org/grpc v1.56.2

--- a/go.sum
+++ b/go.sum
@@ -16,10 +16,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/connector v0.3.0-alpha.0.20230816101622-622978a8ce8b h1:JZVgUHWQUkSPbDCZHlDjWLtvw1aHmMHmcaOOLnCoqNo=
-github.com/instill-ai/connector v0.3.0-alpha.0.20230816101622-622978a8ce8b/go.mod h1:cvOiC8gIcwbck/wYLqNSkY2BodUT9BiMBoJyXjjI+AE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc h1:1akaOOUCsVU2yzFIb5KwVw5GRy7v+hyNmNmJD+2x+l8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/connector v0.3.0-alpha.0.20230817134809-bb4a86dbaaea h1:xe1M6Gc50grThPZ8bfK5vx9N17vazvLj4HeD4lUefgo=
+github.com/instill-ai/connector v0.3.0-alpha.0.20230817134809-bb4a86dbaaea/go.mod h1:bx5IhszAZ/bIJNsQbKqCTY+dr4rJPORhqfP1lwbbHnk=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa h1:QFj7GA+tLaxMCCIJfLMif2y0nPGDCU1+AJF08ORiRhQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/pkg/instill/main.go
+++ b/pkg/instill/main.go
@@ -180,7 +180,7 @@ func (c *Connection) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, err
 	return result, err
 }
 
-func (c *Connection) Test() (connectorPB.Connector_State, error) {
+func (c *Connection) Test() (connectorPB.ConnectorResource_State, error) {
 	// TODO: add api_token validation endpoint in Base
-	return connectorPB.Connector_STATE_CONNECTED, nil
+	return connectorPB.ConnectorResource_STATE_CONNECTED, nil
 }

--- a/pkg/openai/main.go
+++ b/pkg/openai/main.go
@@ -266,14 +266,14 @@ func (c *Connection) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, err
 	return outputs, nil
 }
 
-func (c *Connection) Test() (connectorPB.Connector_State, error) {
+func (c *Connection) Test() (connectorPB.ConnectorResource_State, error) {
 	client := NewClient(c.getAPIKey())
 	models, err := client.ListModels()
 	if err != nil {
-		return connectorPB.Connector_STATE_ERROR, err
+		return connectorPB.ConnectorResource_STATE_ERROR, err
 	}
 	if len(models.Data) == 0 {
-		return connectorPB.Connector_STATE_DISCONNECTED, nil
+		return connectorPB.ConnectorResource_STATE_DISCONNECTED, nil
 	}
-	return connectorPB.Connector_STATE_CONNECTED, nil
+	return connectorPB.ConnectorResource_STATE_CONNECTED, nil
 }

--- a/pkg/stabilityai/main.go
+++ b/pkg/stabilityai/main.go
@@ -271,16 +271,16 @@ func (c *Connection) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, err
 	return outputs, nil
 }
 
-func (c *Connection) Test() (connectorPB.Connector_State, error) {
+func (c *Connection) Test() (connectorPB.ConnectorResource_State, error) {
 	client := NewClient(c.getAPIKey())
 	engines, err := client.ListEngines()
 	if err != nil {
-		return connectorPB.Connector_STATE_ERROR, err
+		return connectorPB.ConnectorResource_STATE_ERROR, err
 	}
 	if len(engines) == 0 {
-		return connectorPB.Connector_STATE_DISCONNECTED, nil
+		return connectorPB.ConnectorResource_STATE_DISCONNECTED, nil
 	}
-	return connectorPB.Connector_STATE_CONNECTED, nil
+	return connectorPB.ConnectorResource_STATE_CONNECTED, nil
 }
 
 // decode if the string is base64 encoded


### PR DESCRIPTION
Because

- In proto, `Connector` has been renamed to `ConnectorResource`

This commit

- use `ConnectorResource_State` enum
