### PR TITLE
chore: adopt new instill-model endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.19
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/connector v0.3.0-alpha.0.20230817134809-bb4a86dbaaea
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa
+	github.com/instill-ai/connector v0.3.0-alpha.0.20230829012922-393407ab343f
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.24.0
 	google.golang.org/grpc v1.56.2

--- a/go.sum
+++ b/go.sum
@@ -16,10 +16,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/connector v0.3.0-alpha.0.20230817134809-bb4a86dbaaea h1:xe1M6Gc50grThPZ8bfK5vx9N17vazvLj4HeD4lUefgo=
-github.com/instill-ai/connector v0.3.0-alpha.0.20230817134809-bb4a86dbaaea/go.mod h1:bx5IhszAZ/bIJNsQbKqCTY+dr4rJPORhqfP1lwbbHnk=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa h1:QFj7GA+tLaxMCCIJfLMif2y0nPGDCU1+AJF08ORiRhQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/connector v0.3.0-alpha.0.20230829012922-393407ab343f h1:0I0fkocfW/Ug1eBrsipAh3rIuRtzq40KDCwLQ4Owlcc=
+github.com/instill-ai/connector v0.3.0-alpha.0.20230829012922-393407ab343f/go.mod h1:CxNAfSjDc/3B2SadH8rXy+0BcDyV15KOjif0ogiWu18=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7 h1:+OhHGpOtFEG+gU5+8wL77JIEZXb9/NICJUwVLRXNARY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/pkg/instill/image_classification.go
+++ b/pkg/instill/image_classification.go
@@ -16,7 +16,7 @@ func (c *Connection) executeImageClassification(grpcClient modelPB.ModelPublicSe
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
 
-	tasklInputs := []*modelPB.TaskInput{}
+	taskInputs := []*modelPB.TaskInput{}
 	for _, input := range inputs {
 
 		inputJson, err := protojson.Marshal(input)
@@ -32,19 +32,19 @@ func (c *Connection) executeImageClassification(grpcClient modelPB.ModelPublicSe
 		taskInput := &modelPB.TaskInput_Classification{
 			Classification: classificationInput,
 		}
-		tasklInputs = append(tasklInputs, &modelPB.TaskInput{Input: taskInput})
+		taskInputs = append(taskInputs, &modelPB.TaskInput{Input: taskInput})
 	}
 
-	req := modelPB.TriggerModelRequest{
+	req := modelPB.TriggerUserModelRequest{
 		Name:       modelName,
-		TaskInputs: tasklInputs,
+		TaskInputs: taskInputs,
 	}
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
 	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
-	res, err := grpcClient.TriggerModel(ctx, &req)
+	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err
 	}

--- a/pkg/instill/instance_segmentation.go
+++ b/pkg/instill/instance_segmentation.go
@@ -16,7 +16,7 @@ func (c *Connection) executeInstanceSegmentation(grpcClient modelPB.ModelPublicS
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
 
-	tasklInputs := []*modelPB.TaskInput{}
+	taskInputs := []*modelPB.TaskInput{}
 	for _, input := range inputs {
 		inputJson, err := protojson.Marshal(input)
 		if err != nil {
@@ -31,18 +31,18 @@ func (c *Connection) executeInstanceSegmentation(grpcClient modelPB.ModelPublicS
 		taskInput := &modelPB.TaskInput_InstanceSegmentation{
 			InstanceSegmentation: segmentationInput,
 		}
-		tasklInputs = append(tasklInputs, &modelPB.TaskInput{Input: taskInput})
+		taskInputs = append(taskInputs, &modelPB.TaskInput{Input: taskInput})
 	}
-	req := modelPB.TriggerModelRequest{
+	req := modelPB.TriggerUserModelRequest{
 		Name:       modelName,
-		TaskInputs: tasklInputs,
+		TaskInputs: taskInputs,
 	}
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
 	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
-	res, err := grpcClient.TriggerModel(ctx, &req)
+	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err
 	}

--- a/pkg/instill/keypoint_detection.go
+++ b/pkg/instill/keypoint_detection.go
@@ -15,7 +15,7 @@ func (c *Connection) executeKeyPointDetection(grpcClient modelPB.ModelPublicServ
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
-	tasklInputs := []*modelPB.TaskInput{}
+	taskInputs := []*modelPB.TaskInput{}
 	for _, input := range inputs {
 		inputJson, err := protojson.Marshal(input)
 		if err != nil {
@@ -30,19 +30,19 @@ func (c *Connection) executeKeyPointDetection(grpcClient modelPB.ModelPublicServ
 		taskInput := &modelPB.TaskInput_Keypoint{
 			Keypoint: keypointInput,
 		}
-		tasklInputs = append(tasklInputs, &modelPB.TaskInput{Input: taskInput})
+		taskInputs = append(taskInputs, &modelPB.TaskInput{Input: taskInput})
 	}
 
-	req := modelPB.TriggerModelRequest{
+	req := modelPB.TriggerUserModelRequest{
 		Name:       modelName,
-		TaskInputs: tasklInputs,
+		TaskInputs: taskInputs,
 	}
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
 	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
-	res, err := grpcClient.TriggerModel(ctx, &req)
+	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err
 	}

--- a/pkg/instill/object_detection.go
+++ b/pkg/instill/object_detection.go
@@ -16,7 +16,7 @@ func (c *Connection) executeObjectDetection(grpcClient modelPB.ModelPublicServic
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
 
-	tasklInputs := []*modelPB.TaskInput{}
+	taskInputs := []*modelPB.TaskInput{}
 	for _, input := range inputs {
 		inputJson, err := protojson.Marshal(input)
 		if err != nil {
@@ -32,12 +32,12 @@ func (c *Connection) executeObjectDetection(grpcClient modelPB.ModelPublicServic
 		modelInput := &modelPB.TaskInput_Detection{
 			Detection: detectionInput,
 		}
-		tasklInputs = append(tasklInputs, &modelPB.TaskInput{Input: modelInput})
+		taskInputs = append(taskInputs, &modelPB.TaskInput{Input: modelInput})
 	}
 
-	req := modelPB.TriggerModelRequest{
+	req := modelPB.TriggerUserModelRequest{
 		Name:       modelName,
-		TaskInputs: tasklInputs,
+		TaskInputs: taskInputs,
 	}
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
@@ -45,7 +45,7 @@ func (c *Connection) executeObjectDetection(grpcClient modelPB.ModelPublicServic
 
 	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
-	res, err := grpcClient.TriggerModel(ctx, &req)
+	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err
 	}

--- a/pkg/instill/ocr.go
+++ b/pkg/instill/ocr.go
@@ -33,7 +33,7 @@ func (c *Connection) executeOCR(grpcClient modelPB.ModelPublicServiceClient, mod
 		}
 
 		// only support batch 1
-		req := modelPB.TriggerModelRequest{
+		req := modelPB.TriggerUserModelRequest{
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
@@ -42,7 +42,7 @@ func (c *Connection) executeOCR(grpcClient modelPB.ModelPublicServiceClient, mod
 		}
 		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
-		res, err := grpcClient.TriggerModel(ctx, &req)
+		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err
 		}

--- a/pkg/instill/semantic_segmentation.go
+++ b/pkg/instill/semantic_segmentation.go
@@ -15,7 +15,7 @@ func (c *Connection) executeSemanticSegmentation(grpcClient modelPB.ModelPublicS
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
-	tasklInputs := []*modelPB.TaskInput{}
+	taskInputs := []*modelPB.TaskInput{}
 	for _, input := range inputs {
 		inputJson, err := protojson.Marshal(input)
 		if err != nil {
@@ -30,20 +30,20 @@ func (c *Connection) executeSemanticSegmentation(grpcClient modelPB.ModelPublicS
 		taskInput := &modelPB.TaskInput_SemanticSegmentation{
 			SemanticSegmentation: semanticSegmentationInput,
 		}
-		tasklInputs = append(tasklInputs, &modelPB.TaskInput{Input: taskInput})
+		taskInputs = append(taskInputs, &modelPB.TaskInput{Input: taskInput})
 
 	}
 
-	req := modelPB.TriggerModelRequest{
+	req := modelPB.TriggerUserModelRequest{
 		Name:       modelName,
-		TaskInputs: tasklInputs,
+		TaskInputs: taskInputs,
 	}
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
 	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
-	res, err := grpcClient.TriggerModel(ctx, &req)
+	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
 		return nil, err
 	}

--- a/pkg/instill/text_generation.go
+++ b/pkg/instill/text_generation.go
@@ -34,7 +34,7 @@ func (c *Connection) executeTextGeneration(grpcClient modelPB.ModelPublicService
 		}
 
 		// only support batch 1
-		req := modelPB.TriggerModelRequest{
+		req := modelPB.TriggerUserModelRequest{
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
@@ -43,7 +43,7 @@ func (c *Connection) executeTextGeneration(grpcClient modelPB.ModelPublicService
 		}
 		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
-		res, err := grpcClient.TriggerModel(ctx, &req)
+		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err
 		}

--- a/pkg/instill/text_to_image.go
+++ b/pkg/instill/text_to_image.go
@@ -33,7 +33,7 @@ func (c *Connection) executeTextToImage(grpcClient modelPB.ModelPublicServiceCli
 		}
 
 		// only support batch 1
-		req := modelPB.TriggerModelRequest{
+		req := modelPB.TriggerUserModelRequest{
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
@@ -42,7 +42,7 @@ func (c *Connection) executeTextToImage(grpcClient modelPB.ModelPublicServiceCli
 		}
 		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
-		res, err := grpcClient.TriggerModel(ctx, &req)
+		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
 			return nil, err
 		}


### PR DESCRIPTION
Because

- the instill-model api endpoints have added namespace in their urls. e.g. `users/<uid>/models/<model_id>`

This commit

- adopt new instill-model endpoints
