### PR TITLE
chore: fix json-schema bug

### DIFF
--- a/pkg/huggingface/config/definitions.json
+++ b/pkg/huggingface/config/definitions.json
@@ -106,7 +106,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -128,7 +128,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -147,7 +147,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -166,7 +166,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -190,7 +190,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "integer",
                               "instillUpstreamType": "value"
@@ -209,7 +209,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -228,7 +228,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -247,7 +247,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -266,7 +266,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "integer",
                               "instillUpstreamType": "value"
@@ -285,7 +285,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -304,7 +304,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -323,7 +323,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "integer",
                               "instillUpstreamType": "value"
@@ -342,7 +342,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -393,7 +393,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -415,7 +415,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -434,7 +434,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -453,7 +453,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -477,7 +477,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -496,7 +496,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "integer",
                               "instillUpstreamType": "value"
@@ -515,7 +515,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "integer",
                               "instillUpstreamType": "value"
@@ -534,7 +534,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "integer",
                               "instillUpstreamType": "value"
@@ -553,7 +553,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -604,7 +604,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -626,7 +626,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -645,7 +645,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -664,7 +664,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -715,7 +715,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -737,7 +737,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -756,7 +756,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -775,7 +775,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -799,7 +799,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "integer",
                               "instillUpstreamType": "value"
@@ -818,7 +818,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "integer",
                               "instillUpstreamType": "value"
@@ -837,7 +837,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "integer",
                               "instillUpstreamType": "value"
@@ -856,7 +856,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -875,7 +875,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -894,7 +894,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -913,7 +913,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -964,7 +964,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -986,7 +986,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1005,7 +1005,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1024,7 +1024,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1075,7 +1075,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -1097,7 +1097,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1116,7 +1116,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1135,7 +1135,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1159,7 +1159,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -1210,7 +1210,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -1232,7 +1232,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1251,7 +1251,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1270,7 +1270,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1322,7 +1322,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -1344,7 +1344,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1363,7 +1363,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1382,7 +1382,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1409,7 +1409,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "array",
                               "items": {
@@ -1431,7 +1431,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1482,7 +1482,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -1504,7 +1504,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1523,7 +1523,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1542,7 +1542,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1600,7 +1600,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -1619,7 +1619,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -1643,7 +1643,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1662,7 +1662,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1681,7 +1681,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1738,7 +1738,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -1770,7 +1770,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1789,7 +1789,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1808,7 +1808,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1865,7 +1865,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -1884,7 +1884,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "array",
                               "items": {
@@ -1911,7 +1911,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1930,7 +1930,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -1949,7 +1949,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -2005,7 +2005,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -2024,7 +2024,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "array",
                               "items": {
@@ -2046,7 +2046,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "array",
                               "items": {
@@ -2073,7 +2073,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -2092,7 +2092,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -2111,7 +2111,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "boolean",
                               "instillUpstreamType": "value"
@@ -2135,7 +2135,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "integer",
                               "instillUpstreamType": "value"
@@ -2154,7 +2154,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "integer",
                               "instillUpstreamType": "value"
@@ -2173,7 +2173,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "integer",
                               "instillUpstreamType": "value"
@@ -2192,7 +2192,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -2211,7 +2211,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -2230,7 +2230,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -2249,7 +2249,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "number",
                               "instillUpstreamType": "value"
@@ -2299,7 +2299,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",
@@ -2343,7 +2343,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",
@@ -2387,7 +2387,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",
@@ -2431,7 +2431,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",
@@ -2475,7 +2475,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",
@@ -2519,7 +2519,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",

--- a/pkg/huggingface/config/seed/generate_definitions.py
+++ b/pkg/huggingface/config/seed/generate_definitions.py
@@ -142,7 +142,7 @@ def convert_field(field):
             "description": field.get("description", ""),
             "instillFormat": field["instillFormat"],
             "instillUpstreamTypes": field["instillUpstreamTypes"],
-            "oneOf": []
+            "anyOf": []
         }
         if title != "":
             field["title"] = title
@@ -151,9 +151,9 @@ def convert_field(field):
         for instillUpstreamType in instill_upstream_types:
             if instillUpstreamType == "value":
                 original_field["instillUpstreamType"] = instillUpstreamType
-                field["oneOf"].append(original_field)
+                field["anyOf"].append(original_field)
             if instillUpstreamType == "reference":
-                field["oneOf"].append({
+                field["anyOf"].append({
                     "type": "string",
                     "pattern": "^\\{.*\\}$",
                     "instillUpstreamType": instillUpstreamType

--- a/pkg/instill/config/definitions.json
+++ b/pkg/instill/config/definitions.json
@@ -97,7 +97,7 @@
                           "instillUpstreamTypes": [
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "pattern": "^\\{.*\\}$",
@@ -113,7 +113,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -176,7 +176,7 @@
                           "instillUpstreamTypes": [
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "pattern": "^\\{.*\\}$",
@@ -192,7 +192,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -255,7 +255,7 @@
                           "instillUpstreamTypes": [
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "pattern": "^\\{.*\\}$",
@@ -271,7 +271,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -334,7 +334,7 @@
                           "instillUpstreamTypes": [
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "pattern": "^\\{.*\\}$",
@@ -350,7 +350,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -413,7 +413,7 @@
                           "instillUpstreamTypes": [
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "pattern": "^\\{.*\\}$",
@@ -429,7 +429,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -492,7 +492,7 @@
                           "instillUpstreamTypes": [
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "pattern": "^\\{.*\\}$",
@@ -508,7 +508,7 @@
                             "value",
                             "reference"
                           ],
-                          "oneOf": [
+                          "anyOf": [
                             {
                               "type": "string",
                               "instillUpstreamType": "value"
@@ -565,7 +565,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -585,7 +585,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -605,7 +605,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "integer",
                           "instillUpstreamType": "value"
@@ -625,7 +625,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -645,7 +645,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -665,7 +665,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "integer",
                           "instillUpstreamType": "value"
@@ -685,7 +685,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "integer",
                           "instillUpstreamType": "value"
@@ -740,7 +740,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -760,7 +760,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -780,7 +780,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "number",
                           "instillUpstreamType": "value"
@@ -800,7 +800,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "integer",
                           "instillUpstreamType": "value"
@@ -820,7 +820,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "integer",
                           "instillUpstreamType": "value"
@@ -840,7 +840,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "integer",
                           "instillUpstreamType": "value"

--- a/pkg/instill/config/seed/generate_definitions.py
+++ b/pkg/instill/config/seed/generate_definitions.py
@@ -126,15 +126,15 @@ def convert_field(field):
             "description": field.get("description", ""),
             "instillFormat": field["instillFormat"],
             "instillUpstreamTypes": field["instillUpstreamTypes"],
-            "oneOf": []
+            "anyOf": []
         }
 
         for instillUpstreamType in instill_upstream_types:
             if instillUpstreamType == "value":
                 original_field["instillUpstreamType"] = instillUpstreamType
-                field["oneOf"].append(original_field)
+                field["anyOf"].append(original_field)
             if instillUpstreamType == "reference":
-                field["oneOf"].append({
+                field["anyOf"].append({
                     "type": "string",
                     "pattern": "^\\{.*\\}$",
                     "instillUpstreamType": instillUpstreamType

--- a/pkg/openai/config/definitions.json
+++ b/pkg/openai/config/definitions.json
@@ -85,7 +85,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -137,7 +137,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "default": "You are a helpful assistant.",
@@ -159,7 +159,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "number",
                           "minimum": 0,
@@ -184,7 +184,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "integer",
                           "minimum": 1,
@@ -209,7 +209,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "default": "inf",
                           "type": "integer",
@@ -265,7 +265,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -341,7 +341,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",
@@ -379,7 +379,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "number",
                           "default": 0,
@@ -400,7 +400,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"
@@ -420,7 +420,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "instillUpstreamType": "value"

--- a/pkg/openai/config/seed/generate_definitions.py
+++ b/pkg/openai/config/seed/generate_definitions.py
@@ -125,15 +125,15 @@ def convert_field(field):
             "description": field.get("description", ""),
             "instillFormat": field["instillFormat"],
             "instillUpstreamTypes": field["instillUpstreamTypes"],
-            "oneOf": []
+            "anyOf": []
         }
 
         for instillUpstreamType in instill_upstream_types:
             if instillUpstreamType == "value":
                 original_field["instillUpstreamType"] = instillUpstreamType
-                field["oneOf"].append(original_field)
+                field["anyOf"].append(original_field)
             if instillUpstreamType == "reference":
-                field["oneOf"].append({
+                field["anyOf"].append({
                     "type": "string",
                     "pattern": "^\\{.*\\}$",
                     "instillUpstreamType": instillUpstreamType

--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -77,7 +77,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",
@@ -92,7 +92,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",
@@ -138,7 +138,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "x-go-type": "uint64",
                           "type": "integer",
@@ -163,7 +163,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "x-go-type": "uint64",
                           "type": "integer",
@@ -188,7 +188,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "number",
                           "default": 7,
@@ -212,7 +212,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "default": "NONE",
@@ -243,7 +243,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "example": "K_DPM_2_ANCESTRAL",
@@ -276,7 +276,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "x-go-type": "uint64",
                           "type": "integer",
@@ -301,7 +301,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "integer",
                           "x-go-type": "uint32",
@@ -326,7 +326,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "x-go-type": "uint64",
                           "type": "integer",
@@ -351,7 +351,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "enum": [
@@ -423,7 +423,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",
@@ -438,7 +438,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",
@@ -453,7 +453,7 @@
                       "instillUpstreamTypes": [
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "pattern": "^\\{.*\\}$",
@@ -499,7 +499,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "enum": [
@@ -524,7 +524,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "number",
                           "example": 0.4,
@@ -549,7 +549,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "number",
                           "default": 0.65,
@@ -573,7 +573,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "number",
                           "example": 0.01,
@@ -596,7 +596,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "number",
                           "default": 7,
@@ -620,7 +620,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "default": "NONE",
@@ -651,7 +651,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "example": "K_DPM_2_ANCESTRAL",
@@ -684,7 +684,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "x-go-type": "uint64",
                           "type": "integer",
@@ -709,7 +709,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "integer",
                           "x-go-type": "uint32",
@@ -734,7 +734,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "x-go-type": "uint64",
                           "type": "integer",
@@ -759,7 +759,7 @@
                         "value",
                         "reference"
                       ],
-                      "oneOf": [
+                      "anyOf": [
                         {
                           "type": "string",
                           "enum": [

--- a/pkg/stabilityai/config/seed/generate_definitions.py
+++ b/pkg/stabilityai/config/seed/generate_definitions.py
@@ -120,15 +120,15 @@ def convert_field(field):
             "description": field.get("description", ""),
             "instillFormat": field["instillFormat"],
             "instillUpstreamTypes": field["instillUpstreamTypes"],
-            "oneOf": []
+            "anyOf": []
         }
 
         for instillUpstreamType in instill_upstream_types:
             if instillUpstreamType == "value":
                 original_field["instillUpstreamType"] = instillUpstreamType
-                field["oneOf"].append(original_field)
+                field["anyOf"].append(original_field)
             if instillUpstreamType == "reference":
-                field["oneOf"].append({
+                field["anyOf"].append({
                     "type": "string",
                     "pattern": "^\\{.*\\}$",
                     "instillUpstreamType": instillUpstreamType


### PR DESCRIPTION
Because

- we should use `anyOf` in json-schema rather than `oneOf`

This commit

- fix json-schema bug
