### PR TITLE
chore: update instillFormat in Instill-Model connector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/connector v0.3.0-alpha.0.20230829012922-393407ab343f
+	github.com/instill-ai/connector v0.3.0-alpha.0.20230911101701-70d06a013fa0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/connector v0.3.0-alpha.0.20230829012922-393407ab343f h1:0I0fkocfW/Ug1eBrsipAh3rIuRtzq40KDCwLQ4Owlcc=
-github.com/instill-ai/connector v0.3.0-alpha.0.20230829012922-393407ab343f/go.mod h1:CxNAfSjDc/3B2SadH8rXy+0BcDyV15KOjif0ogiWu18=
+github.com/instill-ai/connector v0.3.0-alpha.0.20230911101701-70d06a013fa0 h1:Ym/xHs6hOzu0VfkeGPAE4D1MlZnojmun+49KpG4YvPA=
+github.com/instill-ai/connector v0.3.0-alpha.0.20230911101701-70d06a013fa0/go.mod h1:CxNAfSjDc/3B2SadH8rXy+0BcDyV15KOjif0ogiWu18=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7 h1:+OhHGpOtFEG+gU5+8wL77JIEZXb9/NICJUwVLRXNARY=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/instill/config/definitions.json
+++ b/pkg/instill/config/definitions.json
@@ -937,7 +937,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "format": "classification",
+                                "instillFormat": "object",
                                 "additionalProperties": false,
                                 "required": [
                                   "category",
@@ -945,12 +945,14 @@
                                 ],
                                 "properties": {
                                   "category": {
-                                    "description": "The predicted category of the input",
-                                    "type": "string"
+                                    "description": "The predicted category of the input.",
+                                    "type": "string",
+                                    "instillFormat": "text"
                                   },
                                   "score": {
-                                    "description": "The confidence score of the predicted category of the input",
-                                    "type": "number"
+                                    "description": "The confidence score of the predicted category of the input.",
+                                    "type": "number",
+                                    "instillFormat": "number"
                                   }
                                 }
                               }
@@ -1041,17 +1043,19 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "format": "instance_segmentation",
+                                "instillFormat": "object",
                                 "additionalProperties": false,
                                 "required": [
                                   "objects"
                                 ],
                                 "properties": {
                                   "objects": {
-                                    "description": "A list of detected instance bounding boxes",
+                                    "description": "A list of detected instance bounding boxes.",
                                     "type": "array",
+                                    "instillFormat": "object_array",
                                     "items": {
                                       "type": "object",
+                                      "instillFormat": "object",
                                       "required": [
                                         "rle",
                                         "boundingBox",
@@ -1060,13 +1064,14 @@
                                       ],
                                       "properties": {
                                         "rle": {
-                                          "description": "Run Length Encoding (RLE) of instance mask within the bounding box",
-                                          "type": "string"
+                                          "description": "Run Length Encoding (RLE) of instance mask within the bounding box.",
+                                          "type": "string",
+                                          "instillFormat": "text"
                                         },
                                         "boundingBox": {
                                           "type": "object",
-                                          "format": "bounding_box",
-                                          "description": "The detected bounding box in (left, top, width, height) format",
+                                          "instillFormat": "object",
+                                          "description": "The detected bounding box in (left, top, width, height) format.",
                                           "additionalProperties": false,
                                           "required": [
                                             "left",
@@ -1077,29 +1082,35 @@
                                           "properties": {
                                             "left": {
                                               "description": "Bounding box left x-axis value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             },
                                             "top": {
                                               "description": "Bounding box top y-axis value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             },
                                             "width": {
                                               "description": "Bounding box width value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             },
                                             "height": {
                                               "description": "Bounding box height value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             }
                                           }
                                         },
                                         "category": {
-                                          "description": "The predicted category of the bounding box",
-                                          "type": "string"
+                                          "description": "The predicted category of the bounding box.",
+                                          "type": "string",
+                                          "instillFormat": "text"
                                         },
                                         "score": {
-                                          "description": "The confidence score of the predicted instance object",
-                                          "type": "number"
+                                          "description": "The confidence score of the predicted instance object.",
+                                          "type": "number",
+                                          "instillFormat": "number"
                                         }
                                       }
                                     }
@@ -1193,17 +1204,19 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "format": "keypoint",
+                                "instillFormat": "object",
                                 "additionalProperties": false,
                                 "required": [
                                   "objects"
                                 ],
                                 "properties": {
                                   "objects": {
-                                    "description": "A list of keypoint objects, a keypoint object includes all the pre-defined keypoints of a detected object",
+                                    "description": "A list of keypoint objects, a keypoint object includes all the pre-defined keypoints of a detected object.",
                                     "type": "array",
+                                    "instillFormat": "object_array",
                                     "items": {
                                       "type": "object",
+                                      "instillFormat": "object",
                                       "required": [
                                         "keypoints",
                                         "score",
@@ -1211,10 +1224,11 @@
                                       ],
                                       "properties": {
                                         "keypoints": {
-                                          "description": "A keypoint group is composed of a list of pre-defined keypoints of a detected object",
-                                          "type": "array",
+                                          "description": "A keypoint group is composed of a list of pre-defined keypoints of a detected object.",
+                                          "type": "object_array",
                                           "items": {
                                             "type": "object",
+                                            "instillFormat": "object",
                                             "required": [
                                               "x",
                                               "y",
@@ -1222,28 +1236,32 @@
                                             ],
                                             "properties": {
                                               "x": {
-                                                "description": "x coordinate of the keypoint",
-                                                "type": "number"
+                                                "description": "x coordinate of the keypoint.",
+                                                "type": "number",
+                                                "instillFormat": "number"
                                               },
                                               "y": {
-                                                "description": "y coordinate of the keypoint",
-                                                "type": "number"
+                                                "description": "y coordinate of the keypoint.",
+                                                "type": "number",
+                                                "instillFormat": "number"
                                               },
                                               "v": {
-                                                "description": "visibility score of the keypoint",
-                                                "type": "number"
+                                                "description": "visibility score of the keypoint.",
+                                                "type": "number",
+                                                "instillFormat": "number"
                                               }
                                             }
                                           }
                                         },
                                         "score": {
-                                          "description": "The confidence score of the predicted object",
-                                          "type": "number"
+                                          "description": "The confidence score of the predicted object.",
+                                          "type": "number",
+                                          "instillFormat": "number"
                                         },
                                         "bounding_box": {
                                           "type": "object",
-                                          "format": "bounding_box",
-                                          "description": "The detected bounding box in (left, top, width, height) format",
+                                          "instillFormat": "object",
+                                          "description": "The detected bounding box in (left, top, width, height) format.",
                                           "additionalProperties": false,
                                           "required": [
                                             "left",
@@ -1254,19 +1272,23 @@
                                           "properties": {
                                             "left": {
                                               "description": "Bounding box left x-axis value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             },
                                             "top": {
                                               "description": "Bounding box top y-axis value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             },
                                             "width": {
                                               "description": "Bounding box width value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             },
                                             "height": {
                                               "description": "Bounding box height value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             }
                                           }
                                         }
@@ -1362,17 +1384,19 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "format": "detection",
+                                "instillFormat": "object",
                                 "additionalProperties": false,
                                 "required": [
                                   "objects"
                                 ],
                                 "properties": {
                                   "objects": {
-                                    "description": "A list of detected objects",
+                                    "description": "A list of detected objects.",
                                     "type": "array",
+                                    "instillFormat": "object_array",
                                     "items": {
                                       "type": "object",
+                                      "instillFormat": "object",
                                       "additionalProperties": false,
                                       "required": [
                                         "bounding_box",
@@ -1382,8 +1406,8 @@
                                       "properties": {
                                         "bounding_box": {
                                           "type": "object",
-                                          "format": "bounding_box",
-                                          "description": "The detected bounding box in (left, top, width, height) format",
+                                          "instillFormat": "object",
+                                          "description": "The detected bounding box in (left, top, width, height) format.",
                                           "additionalProperties": false,
                                           "required": [
                                             "left",
@@ -1394,29 +1418,35 @@
                                           "properties": {
                                             "left": {
                                               "description": "Bounding box left x-axis value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             },
                                             "top": {
                                               "description": "Bounding box top y-axis value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             },
                                             "width": {
                                               "description": "Bounding box width value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             },
                                             "height": {
                                               "description": "Bounding box height value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             }
                                           }
                                         },
                                         "category": {
-                                          "description": "The predicted category of the bounding box",
-                                          "type": "string"
+                                          "description": "The predicted category of the bounding box.",
+                                          "type": "string",
+                                          "instillFormat": "text"
                                         },
                                         "score": {
-                                          "description": "The confidence score of the predicted category of the bounding box",
-                                          "type": "number"
+                                          "description": "The confidence score of the predicted category of the bounding box.",
+                                          "type": "number",
+                                          "instillFormat": "number"
                                         }
                                       }
                                     }
@@ -1510,17 +1540,19 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "format": "ocr",
+                                "instillFormat": "object",
                                 "additionalProperties": false,
                                 "required": [
                                   "objects"
                                 ],
                                 "properties": {
                                   "objects": {
-                                    "description": "A list of detected bounding boxes",
+                                    "description": "A list of detected bounding boxes.",
                                     "type": "array",
+                                    "instillFormat": "object_array",
                                     "items": {
                                       "type": "object",
+                                      "instillFormat": "object",
                                       "required": [
                                         "boundingBox",
                                         "text",
@@ -1529,8 +1561,8 @@
                                       "properties": {
                                         "boundingBox": {
                                           "type": "object",
-                                          "format": "bounding_box",
-                                          "description": "The detected bounding box in (left, top, width, height) format",
+                                          "instillFormat": "object",
+                                          "description": "The detected bounding box in (left, top, width, height) format.",
                                           "additionalProperties": false,
                                           "required": [
                                             "left",
@@ -1541,29 +1573,35 @@
                                           "properties": {
                                             "left": {
                                               "description": "Bounding box left x-axis value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             },
                                             "top": {
                                               "description": "Bounding box top y-axis value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             },
                                             "width": {
                                               "description": "Bounding box width value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             },
                                             "height": {
                                               "description": "Bounding box height value",
-                                              "type": "number"
+                                              "type": "number",
+                                              "instillFormat": "number"
                                             }
                                           }
                                         },
                                         "text": {
-                                          "description": "Text string recognised per bounding box",
-                                          "type": "string"
+                                          "description": "Text string recognised per bounding box.",
+                                          "type": "string",
+                                          "instillFormat": "text"
                                         },
                                         "score": {
-                                          "description": "The confidence score of the predicted object",
-                                          "type": "number"
+                                          "description": "The confidence score of the predicted object.",
+                                          "type": "number",
+                                          "instillFormat": "number"
                                         }
                                       }
                                     }
@@ -1657,29 +1695,33 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "format": "semantic_segmentation",
+                                "instillFormat": "object",
                                 "additionalProperties": false,
                                 "required": [
                                   "stuffs"
                                 ],
                                 "properties": {
                                   "stuffs": {
-                                    "description": "A list of RLE binary masks",
+                                    "description": "A list of RLE binary masks.",
                                     "type": "array",
+                                    "instillFormat": "object_array",
                                     "items": {
                                       "type": "object",
+                                      "instillFormat": "object",
                                       "required": [
                                         "rle",
                                         "category"
                                       ],
                                       "properties": {
                                         "rle": {
-                                          "description": "Run Length Encoding (RLE) of each stuff mask within the image",
-                                          "type": "string"
+                                          "description": "Run Length Encoding (RLE) of each stuff mask within the image.",
+                                          "type": "string",
+                                          "instillFormat": "text"
                                         },
                                         "category": {
-                                          "description": "Category text string corresponding to each stuff mask",
-                                          "type": "string"
+                                          "description": "Category text string corresponding to each stuff mask.",
+                                          "type": "string",
+                                          "instillFormat": "text"
                                         }
                                       }
                                     }
@@ -1813,7 +1855,7 @@
                                 "properties": {
                                   "text": {
                                     "type": "string",
-                                    "instillFormat": "object"
+                                    "instillFormat": "text"
                                   }
                                 }
                               }

--- a/pkg/instill/config/seed/data.json
+++ b/pkg/instill/config/seed/data.json
@@ -33,7 +33,7 @@
     },
     "output": {
       "type": "object",
-      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/622978a8ce8b5c4f2242afad7e5ba7d4d18cab27/shared_schema.json#/$defs/instill_types/classification"
+      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/classification"
     }
   },
   "TASK_INSTANCE_SEGMENTATION": {
@@ -49,7 +49,7 @@
     },
     "output": {
       "type": "object",
-      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/622978a8ce8b5c4f2242afad7e5ba7d4d18cab27/shared_schema.json#/$defs/instill_types/instance_segmentation"
+      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/instance_segmentation"
     }
   },
   "TASK_KEYPOINT": {
@@ -65,7 +65,7 @@
     },
     "output": {
       "type": "object",
-      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/622978a8ce8b5c4f2242afad7e5ba7d4d18cab27/shared_schema.json#/$defs/instill_types/keypoint"
+      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/keypoint"
     }
   },
   "TASK_DETECTION": {
@@ -81,7 +81,7 @@
     },
     "output": {
       "type": "object",
-      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/622978a8ce8b5c4f2242afad7e5ba7d4d18cab27/shared_schema.json#/$defs/instill_types/detection"
+      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/detection"
     }
   },
   "TASK_OCR": {
@@ -94,7 +94,7 @@
     },
     "output": {
       "type": "object",
-      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/622978a8ce8b5c4f2242afad7e5ba7d4d18cab27/shared_schema.json#/$defs/instill_types/ocr"
+      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/ocr"
     }
   },
   "TASK_SEMANTIC_SEGMENTATION": {
@@ -110,7 +110,7 @@
     },
     "output": {
       "type": "object",
-      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/622978a8ce8b5c4f2242afad7e5ba7d4d18cab27/shared_schema.json#/$defs/instill_types/semantic_segmentation"
+      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/semantic_segmentation"
     }
   },
   "TASK_TEXT_GENERATION": {
@@ -169,7 +169,7 @@
       "properties": {
         "text": {
           "type": "string",
-          "instillFormat": "object"
+          "instillFormat": "text"
         }
       }
     }


### PR DESCRIPTION
Because

- we need to use instillFormat to hint user for the type on Console

This commit

- update instillFormat in Instill-Model connector
