### PR TITLE
chore: update schema for OpenAI and Stability AI connector

### DIFF
--- a/pkg/openai/config/definitions.json
+++ b/pkg/openai/config/definitions.json
@@ -689,11 +689,11 @@
                                 "properties": {
                                   "embedding": {
                                     "type": "array",
-                                    "format": "embedding",
+                                    "instillFormat": "number_array",
                                     "items": {
-                                      "type": "number"
-                                    },
-                                    "instillFormat": "number_array"
+                                      "type": "number",
+                                      "instillFormat": "number"
+                                    }
                                   }
                                 }
                               }

--- a/pkg/openai/config/seed/data.json
+++ b/pkg/openai/config/seed/data.json
@@ -79,7 +79,7 @@
       "type": "object",
       "properties": {
         "embedding": {
-          "$ref": "https://raw.githubusercontent.com/instill-ai/connector/622978a8ce8b5c4f2242afad7e5ba7d4d18cab27/shared_schema.json#/$defs/instill_types/embedding",
+          "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/embedding",
           "instillFormat": "number_array"
         }
       }

--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -851,7 +851,8 @@
                                     "type": "number",
                                     "description": "Weight of the prompt (use negative numbers for negative prompts)",
                                     "example": 0.8167237,
-                                    "format": "float"
+                                    "format": "float",
+                                    "instillFormat": "number"
                                   },
                                   "minItems": 1,
                                   "instillFormat": "number_array",
@@ -1080,7 +1081,8 @@
                                     "title": "Images",
                                     "type": "array",
                                     "items": {
-                                      "type": "string"
+                                      "type": "string",
+                                      "instillFormat": "image"
                                     },
                                     "instillFormat": "image_array"
                                   },
@@ -1090,7 +1092,8 @@
                                     "items": {
                                       "type": "number",
                                       "description": "The seed associated with this image",
-                                      "example": 1229191277
+                                      "example": 1229191277,
+                                      "instillFormat": "number"
                                     },
                                     "instillFormat": "number_array"
                                   }
@@ -1159,7 +1162,8 @@
                                     "type": "number",
                                     "description": "Weight of the prompt (use negative numbers for negative prompts)",
                                     "example": 0.8167237,
-                                    "format": "float"
+                                    "format": "float",
+                                    "instillFormat": "number"
                                   },
                                   "minItems": 1,
                                   "instillFormat": "number_array",
@@ -1427,7 +1431,8 @@
                                     "title": "Images",
                                     "type": "array",
                                     "items": {
-                                      "type": "string"
+                                      "type": "string",
+                                      "instillFormat": "image"
                                     },
                                     "instillFormat": "image_array"
                                   },
@@ -1437,7 +1442,8 @@
                                     "items": {
                                       "type": "number",
                                       "description": "The seed associated with this image",
-                                      "example": 1229191277
+                                      "example": 1229191277,
+                                      "instillFormat": "number"
                                     },
                                     "instillFormat": "number_array"
                                   }

--- a/pkg/stabilityai/config/seed/data.json
+++ b/pkg/stabilityai/config/seed/data.json
@@ -24,7 +24,8 @@
           "type": "array",
           "description": "An array of weights to use for generation.",
           "items": {
-            "$ref": "stabilityai.json#/components/schemas/TextPrompt/properties/weight"
+            "$ref": "stabilityai.json#/components/schemas/TextPrompt/properties/weight",
+            "instillFormat": "number"
           },
           "minItems": 1,
           "instillFormat": "number_array",
@@ -122,7 +123,8 @@
           "title": "Images",
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "instillFormat": "image"
           },
           "instillFormat": "image_array"
         },
@@ -130,7 +132,8 @@
           "title": "Seeds",
           "type": "array",
           "items": {
-            "$ref": "stabilityai.json#/components/schemas/Image/properties/seed"
+            "$ref": "stabilityai.json#/components/schemas/Image/properties/seed",
+            "instillFormat": "number"
           },
           "instillFormat": "number_array"
         }
@@ -162,7 +165,8 @@
           "type": "array",
           "description": "An array of weights to use for generation.",
           "items": {
-            "$ref": "stabilityai.json#/components/schemas/TextPrompt/properties/weight"
+            "$ref": "stabilityai.json#/components/schemas/TextPrompt/properties/weight",
+            "instillFormat": "number"
           },
           "minItems": 1,
           "instillFormat": "number_array",


### PR DESCRIPTION
Because

- some of the instillFormat annotations are missing

This commit

- update schema for OpenAI and Stability AI connector
