### PR TITLE
refactor(all): adopt new base interfaces from Component pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.19
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/component v0.4.0-alpha.0.20230925162635-046f0900f997
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7
+	github.com/instill-ai/component v0.4.0-alpha.0.20230925171029-e3485c428e72
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230925170910-6416b8d2be1a
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.24.0
 	google.golang.org/grpc v1.56.2

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/connector v0.4.0-alpha
+	github.com/instill-ai/component v0.4.0-alpha.0.20230925162635-046f0900f997
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -16,10 +16,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.4.0-alpha.0.20230925162635-046f0900f997 h1:mlpjP8SYfoQDZKtcdrVqcIdfoVX3KQ8hCNuxUBESEQ4=
-github.com/instill-ai/component v0.4.0-alpha.0.20230925162635-046f0900f997/go.mod h1:HnikLnUDhK7Lqu+f9ose392aG+4IxzIUstomf8gD3kU=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7 h1:+OhHGpOtFEG+gU5+8wL77JIEZXb9/NICJUwVLRXNARY=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/component v0.4.0-alpha.0.20230925171029-e3485c428e72 h1:Vpgoi645V6gs7p2oq4iAObihnH/CLmTG/yoChLMFvEY=
+github.com/instill-ai/component v0.4.0-alpha.0.20230925171029-e3485c428e72/go.mod h1:NoA019Wyez+2q8cfIiDGLOGfkSIm/lC/o1wOOU73oV0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230925170910-6416b8d2be1a h1:b8M9EZv80v5VUz1+xDgn+H3w9+rQks1e7QDoTOUg7CE=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230925170910-6416b8d2be1a/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/connector v0.4.0-alpha h1:7BETAfjw02cwHU7Q+fAhBaZkvumsnAQD2u7AbXZiz/A=
-github.com/instill-ai/connector v0.4.0-alpha/go.mod h1:CxNAfSjDc/3B2SadH8rXy+0BcDyV15KOjif0ogiWu18=
+github.com/instill-ai/component v0.4.0-alpha.0.20230925162635-046f0900f997 h1:mlpjP8SYfoQDZKtcdrVqcIdfoVX3KQ8hCNuxUBESEQ4=
+github.com/instill-ai/component v0.4.0-alpha.0.20230925162635-046f0900f997/go.mod h1:HnikLnUDhK7Lqu+f9ose392aG+4IxzIUstomf8gD3kU=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7 h1:+OhHGpOtFEG+gU5+8wL77JIEZXb9/NICJUwVLRXNARY=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/instill/config/seed/data.json
+++ b/pkg/instill/config/seed/data.json
@@ -33,7 +33,7 @@
     },
     "output": {
       "type": "object",
-      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/classification"
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/classification"
     }
   },
   "TASK_INSTANCE_SEGMENTATION": {
@@ -49,7 +49,7 @@
     },
     "output": {
       "type": "object",
-      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/instance_segmentation"
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/instance_segmentation"
     }
   },
   "TASK_KEYPOINT": {
@@ -65,7 +65,7 @@
     },
     "output": {
       "type": "object",
-      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/keypoint"
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/keypoint"
     }
   },
   "TASK_DETECTION": {
@@ -81,7 +81,7 @@
     },
     "output": {
       "type": "object",
-      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/detection"
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/detection"
     }
   },
   "TASK_OCR": {
@@ -94,7 +94,7 @@
     },
     "output": {
       "type": "object",
-      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/ocr"
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/ocr"
     }
   },
   "TASK_SEMANTIC_SEGMENTATION": {
@@ -110,7 +110,7 @@
     },
     "output": {
       "type": "object",
-      "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/semantic_segmentation"
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/semantic_segmentation"
     }
   },
   "TASK_TEXT_GENERATION": {

--- a/pkg/instill/image_classification.go
+++ b/pkg/instill/image_classification.go
@@ -42,7 +42,7 @@ func (c *Connection) executeImageClassification(grpcClient modelPB.ModelPublicSe
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/instance_segmentation.go
+++ b/pkg/instill/instance_segmentation.go
@@ -40,7 +40,7 @@ func (c *Connection) executeInstanceSegmentation(grpcClient modelPB.ModelPublicS
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/keypoint_detection.go
+++ b/pkg/instill/keypoint_detection.go
@@ -40,7 +40,7 @@ func (c *Connection) executeKeyPointDetection(grpcClient modelPB.ModelPublicServ
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/object_detection.go
+++ b/pkg/instill/object_detection.go
@@ -43,7 +43,7 @@ func (c *Connection) executeObjectDetection(grpcClient modelPB.ModelPublicServic
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
 
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/ocr.go
+++ b/pkg/instill/ocr.go
@@ -40,7 +40,7 @@ func (c *Connection) executeOCR(grpcClient modelPB.ModelPublicServiceClient, mod
 		if c.client == nil || grpcClient == nil {
 			return nil, fmt.Errorf("client not setup: %v", c.client)
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/semantic_segmentation.go
+++ b/pkg/instill/semantic_segmentation.go
@@ -41,7 +41,7 @@ func (c *Connection) executeSemanticSegmentation(grpcClient modelPB.ModelPublicS
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/text_generation.go
+++ b/pkg/instill/text_generation.go
@@ -41,7 +41,7 @@ func (c *Connection) executeTextGeneration(grpcClient modelPB.ModelPublicService
 		if c.client == nil || grpcClient == nil {
 			return nil, fmt.Errorf("client not setup: %v", c.client)
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/text_to_image.go
+++ b/pkg/instill/text_to_image.go
@@ -40,7 +40,7 @@ func (c *Connection) executeTextToImage(grpcClient modelPB.ModelPublicServiceCli
 		if c.client == nil || grpcClient == nil {
 			return nil, fmt.Errorf("client not setup: %v", c.client)
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", c.getAPIKey()))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -14,17 +14,17 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/instill-ai/component/pkg/base"
 	"github.com/instill-ai/connector-ai/pkg/huggingface"
 	"github.com/instill-ai/connector-ai/pkg/openai"
 	"github.com/instill-ai/connector-ai/pkg/stabilityai"
-	"github.com/instill-ai/connector/pkg/base"
 )
 
 var (
 	stabilityAIKey = "<valid api key>"
 	openAIKey      = "<valid api key>"
 	huggingFaceKey = "<valid api key>"
-	hfCon          base.IConnection
+	hfCon          base.IExecution
 )
 
 func init() {
@@ -41,7 +41,7 @@ func init() {
 			"is_custom_endpoint": {Kind: &structpb.Value_BoolValue{BoolValue: false}},
 		}}
 	c := Init(nil, ConnectorOptions{})
-	hfCon, _ = c.CreateConnection(c.ListConnectorDefinitionUids()[3], hfConfig, nil)
+	hfCon, _ = c.CreateExecution(c.ListConnectorDefinitionUids()[3], hfConfig, nil)
 }
 
 func TestStabilityAITextToImage(t *testing.T) {
@@ -58,7 +58,7 @@ func TestStabilityAITextToImage(t *testing.T) {
 	in, err := base.ConvertToStructpb(inputStruct)
 	fmt.Printf("err:%s", err)
 	c := Init(nil, ConnectorOptions{})
-	con, err := c.CreateConnection(c.ListConnectorDefinitionUids()[0], config, nil)
+	con, err := c.CreateExecution(c.ListConnectorDefinitionUids()[0], config, nil)
 	fmt.Printf("err:%s", err)
 	op, err := con.Execute([]*structpb.Struct{in})
 	fmt.Printf("\n op :%v, err:%s", op, err)
@@ -86,7 +86,7 @@ func TestStabilityAIImageToImage(t *testing.T) {
 	in, err := base.ConvertToStructpb(inputStruct)
 	fmt.Printf("err:%s", err)
 	c := Init(nil, ConnectorOptions{})
-	con, err := c.CreateConnection(c.ListConnectorDefinitionUids()[0], config, nil)
+	con, err := c.CreateExecution(c.ListConnectorDefinitionUids()[0], config, nil)
 	fmt.Printf("\n err: %s", err)
 	op, err := con.Execute([]*structpb.Struct{in})
 	fmt.Printf("\n op: %v, err: %s", op, err)
@@ -102,7 +102,7 @@ func TestOpenAITextGeneration(t *testing.T) {
 	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "TASK_TEXT_GENERATION"}}
 	fmt.Printf("err:%s", err)
 	c := Init(nil, ConnectorOptions{})
-	con, err := c.CreateConnection(c.ListConnectorDefinitionUids()[2], config, nil)
+	con, err := c.CreateExecution(c.ListConnectorDefinitionUids()[2], config, nil)
 	fmt.Printf("err:%s", err)
 	op, err := con.Execute([]*structpb.Struct{in})
 	fmt.Printf("\n op :%v, err:%s", op, err)
@@ -132,7 +132,7 @@ func TestOpenAIAudioTranscription(t *testing.T) {
 	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "TASK_SPEECH_RECOGNITION"}}
 	fmt.Printf("err:%s", err)
 	c := Init(nil, ConnectorOptions{})
-	con, err := c.CreateConnection(c.ListConnectorDefinitionUids()[2], config, nil)
+	con, err := c.CreateExecution(c.ListConnectorDefinitionUids()[2], config, nil)
 	fmt.Printf("err:%s", err)
 	op, err := con.Execute([]*structpb.Struct{in})
 	fmt.Printf("\n op :%v, err:%s", op, err)
@@ -393,7 +393,7 @@ func TestHuggingFaceCustomEndpointImageClassification(t *testing.T) {
 			"is_custom_endpoint": {Kind: &structpb.Value_BoolValue{BoolValue: true}},
 		}}
 	c := Init(nil, ConnectorOptions{})
-	hfCustomCon, _ := c.CreateConnection(c.ListConnectorDefinitionUids()[3], hfCustomConfig, nil)
+	hfCustomCon, _ := c.CreateExecution(c.ListConnectorDefinitionUids()[3], hfCustomConfig, nil)
 
 	b, _ := ioutil.ReadFile("test_artifacts/image.jpg")
 	req := huggingface.ImageRequest{Image: base64.StdEncoding.EncodeToString(b)}

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -8,11 +8,13 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/instill-ai/component/pkg/base"
 	"github.com/instill-ai/connector-ai/pkg/huggingface"
 	"github.com/instill-ai/connector-ai/pkg/instill"
 	"github.com/instill-ai/connector-ai/pkg/openai"
 	"github.com/instill-ai/connector-ai/pkg/stabilityai"
-	"github.com/instill-ai/connector/pkg/base"
+
+	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
 )
 
 var once sync.Once
@@ -91,17 +93,32 @@ func Init(logger *zap.Logger, options ConnectorOptions) base.IConnector {
 	return connector
 }
 
-func (c *Connector) CreateConnection(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (base.IConnection, error) {
+func (c *Connector) CreateExecution(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (base.IExecution, error) {
 	switch {
 	case c.stabilityAIConnector.HasUid(defUid):
-		return c.stabilityAIConnector.CreateConnection(defUid, config, logger)
+		return c.stabilityAIConnector.CreateExecution(defUid, config, logger)
 	case c.instillConnector.HasUid(defUid):
-		return c.instillConnector.CreateConnection(defUid, config, logger)
+		return c.instillConnector.CreateExecution(defUid, config, logger)
 	case c.openAIConnector.HasUid(defUid):
-		return c.openAIConnector.CreateConnection(defUid, config, logger)
+		return c.openAIConnector.CreateExecution(defUid, config, logger)
 	case c.huggingFaceConnector.HasUid(defUid):
-		return c.huggingFaceConnector.CreateConnection(defUid, config, logger)
+		return c.huggingFaceConnector.CreateExecution(defUid, config, logger)
 	default:
 		return nil, fmt.Errorf("no aiConnector uid: %s", defUid)
+	}
+}
+
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+	switch {
+	case c.stabilityAIConnector.HasUid(defUid):
+		return c.stabilityAIConnector.Test(defUid, config, logger)
+	case c.instillConnector.HasUid(defUid):
+		return c.instillConnector.Test(defUid, config, logger)
+	case c.openAIConnector.HasUid(defUid):
+		return c.openAIConnector.Test(defUid, config, logger)
+	case c.huggingFaceConnector.HasUid(defUid):
+		return c.huggingFaceConnector.Test(defUid, config, logger)
+	default:
+		return connectorPB.ConnectorResource_STATE_ERROR, fmt.Errorf("no connector uid: %s", defUid)
 	}
 }

--- a/pkg/openai/config/seed/data.json
+++ b/pkg/openai/config/seed/data.json
@@ -79,7 +79,7 @@
       "type": "object",
       "properties": {
         "embedding": {
-          "$ref": "https://raw.githubusercontent.com/instill-ai/connector/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/embedding",
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/embedding",
           "instillFormat": "number_array"
         }
       }


### PR DESCRIPTION
Because

- we refactored the base interface `IConnector` and `IExecution`

This commit

- adopt new base interfaces
