### PR TITLE
chore: add link to get api keys

### DIFF
--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -18,7 +18,7 @@
         "properties": {
           "api_key": {
             "title": "API Key",
-            "description": "Fill your Stability AI API key. To find your keys, navigate to your DreamStudio's Account page.",
+            "description": "Fill your Stability AI API key. To find your keys, visit - https://platform.stability.ai/account/keys",
             "type": "string",
             "credential_field": true
           }

--- a/pkg/stabilityai/config/seed/resource.json
+++ b/pkg/stabilityai/config/seed/resource.json
@@ -2,12 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Stability AI Connector Spec",
   "type": "object",
-  "required": ["api_key"],
+  "required": [
+    "api_key"
+  ],
   "additionalProperties": false,
   "properties": {
     "api_key": {
       "title": "API Key",
-      "description": "Fill your Stability AI API key. To find your keys, navigate to your DreamStudio's Account page.",
+      "description": "Fill your Stability AI API key. To find your keys, visit - https://platform.stability.ai/account/keys",
       "type": "string",
       "credential_field": true
     }


### PR DESCRIPTION
Because

- we have received feedback from users saying a link to generate API key would be helpful

This commit

- updates the description of OpenAI and Stability AI connectors to add the link
